### PR TITLE
fix: 修复 ajaxm 数组索引越界导致解析失败的问题

### DIFF
--- a/index.php
+++ b/index.php
@@ -117,7 +117,8 @@ if(strpos($softInfo, "function down_p(){") != false  && empty($webpage)) {
 		    "ves" => 1
 	    );
 	}
-	$softInfo = MloocCurlPost($post_data, "https://www.lanzouf.com/".$ajaxm[0][1], $ifurl);
+	$ajaxmPath = $ajaxm[0][1] ?? $ajaxm[0][0] ?? '';
+	$softInfo = MloocCurlPost($post_data, "https://www.lanzouf.com/" . $ajaxmPath, $ifurl);
 }
 //其他情况下的信息输出
 $softInfo = json_decode($softInfo, true);


### PR DESCRIPTION
当 $ajaxm[0] 只有一个元素时，$ajaxm[0][1] 为 null 导致请求 URL 错误，返回 {"code":400,"msg":null}。改为优先取 [0][1]，取不到则回退到 [0][0]，兼容两种情况。